### PR TITLE
Update pool registration logic

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -199,7 +199,6 @@ func syncRegistry() {
 
 	ctx := context.Background()
 
-
 	onchainTokens, err := regClient.Tokens(ctx)
 	if err != nil {
 		log.Printf("registry token query error: %v", err)
@@ -309,6 +308,47 @@ func profitLogHandler(l types.Log) {
 	}
 }
 
+// recordPool caches the given pool and tokens and updates the registry if needed.
+func recordPool(pool, token0, token1 common.Address) {
+	if marketStore != nil {
+		if !marketStore.HasToken(token0) {
+			marketStore.AddToken(token0)
+		}
+		if !marketStore.HasToken(token1) {
+			marketStore.AddToken(token1)
+		}
+		if !marketStore.Has(pool) {
+			marketStore.AddPool(pool, token0, token1)
+		}
+	}
+	if regClient != nil {
+		if _, ok := knownTokens[token0]; !ok {
+			if tx, err := regClient.AddToken(token0, 18); err != nil {
+				log.Printf("registry token0 error: %v", err)
+			} else {
+				log.Printf("registry add token %s tx=%s", token0.Hex(), tx.Hash().Hex())
+				knownTokens[token0] = struct{}{}
+			}
+		}
+		if _, ok := knownTokens[token1]; !ok {
+			if tx, err := regClient.AddToken(token1, 18); err != nil {
+				log.Printf("registry token1 error: %v", err)
+			} else {
+				log.Printf("registry add token %s tx=%s", token1.Hex(), tx.Hash().Hex())
+				knownTokens[token1] = struct{}{}
+			}
+		}
+		if _, ok := knownPools[pool]; !ok {
+			if tx, err := regClient.AddPool(pool, token0, token1, 0); err != nil {
+				log.Printf("registry pool error: %v", err)
+			} else {
+				log.Printf("registry add pool %s tx=%s", pool.Hex(), tx.Hash().Hex())
+				knownPools[pool] = struct{}{}
+			}
+		}
+	}
+}
+
 // pairLogHandler collects pool addresses from factory events.
 func pairLogHandler(l types.Log) {
 	if len(l.Topics) == 0 {
@@ -328,43 +368,7 @@ func pairLogHandler(l types.Log) {
 				ev.Token1 = common.BytesToAddress(l.Topics[2].Bytes())
 			}
 			log.Printf("pair created %s", ev.Pair.Hex())
-			if marketStore != nil {
-				if !marketStore.HasToken(ev.Token0) {
-					marketStore.AddToken(ev.Token0)
-				}
-				if !marketStore.HasToken(ev.Token1) {
-					marketStore.AddToken(ev.Token1)
-				}
-				if !marketStore.Has(ev.Pair) {
-					marketStore.AddPool(ev.Pair, ev.Token0, ev.Token1)
-				}
-			}
-			if regClient != nil {
-				if _, ok := knownTokens[ev.Token0]; !ok {
-					if tx, err := regClient.AddToken(ev.Token0, 18); err != nil {
-						log.Printf("registry token0 error: %v", err)
-					} else {
-						log.Printf("registry add token %s tx=%s", ev.Token0.Hex(), tx.Hash().Hex())
-						knownTokens[ev.Token0] = struct{}{}
-					}
-				}
-				if _, ok := knownTokens[ev.Token1]; !ok {
-					if tx, err := regClient.AddToken(ev.Token1, 18); err != nil {
-						log.Printf("registry token1 error: %v", err)
-					} else {
-						log.Printf("registry add token %s tx=%s", ev.Token1.Hex(), tx.Hash().Hex())
-						knownTokens[ev.Token1] = struct{}{}
-					}
-				}
-				if _, ok := knownPools[ev.Pair]; !ok {
-					if tx, err := regClient.AddPool(ev.Pair, ev.Token0, ev.Token1, 0); err != nil {
-						log.Printf("registry pool error: %v", err)
-					} else {
-						log.Printf("registry add pool %s tx=%s", ev.Pair.Hex(), tx.Hash().Hex())
-						knownPools[ev.Pair] = struct{}{}
-					}
-				}
-			}
+			recordPool(ev.Pair, ev.Token0, ev.Token1)
 		} else {
 			log.Printf("pair decode error: %v", err)
 		}
@@ -382,43 +386,7 @@ func pairLogHandler(l types.Log) {
 				ev.Token1 = common.BytesToAddress(l.Topics[2].Bytes())
 			}
 			log.Printf("pool created %s", ev.Pool.Hex())
-			if marketStore != nil {
-				if !marketStore.HasToken(ev.Token0) {
-					marketStore.AddToken(ev.Token0)
-				}
-				if !marketStore.HasToken(ev.Token1) {
-					marketStore.AddToken(ev.Token1)
-				}
-				if !marketStore.Has(ev.Pool) {
-					marketStore.AddPool(ev.Pool, ev.Token0, ev.Token1)
-				}
-			}
-			if regClient != nil {
-				if _, ok := knownTokens[ev.Token0]; !ok {
-					if tx, err := regClient.AddToken(ev.Token0, 18); err != nil {
-						log.Printf("registry token0 error: %v", err)
-					} else {
-						log.Printf("registry add token %s tx=%s", ev.Token0.Hex(), tx.Hash().Hex())
-						knownTokens[ev.Token0] = struct{}{}
-					}
-				}
-				if _, ok := knownTokens[ev.Token1]; !ok {
-					if tx, err := regClient.AddToken(ev.Token1, 18); err != nil {
-						log.Printf("registry token1 error: %v", err)
-					} else {
-						log.Printf("registry add token %s tx=%s", ev.Token1.Hex(), tx.Hash().Hex())
-						knownTokens[ev.Token1] = struct{}{}
-					}
-				}
-				if _, ok := knownPools[ev.Pool]; !ok {
-					if tx, err := regClient.AddPool(ev.Pool, ev.Token0, ev.Token1, 0); err != nil {
-						log.Printf("registry pool error: %v", err)
-					} else {
-						log.Printf("registry add pool %s tx=%s", ev.Pool.Hex(), tx.Hash().Hex())
-						knownPools[ev.Pool] = struct{}{}
-					}
-				}
-			}
+			recordPool(ev.Pool, ev.Token0, ev.Token1)
 		} else {
 			log.Printf("pool decode error: %v", err)
 		}
@@ -478,33 +446,7 @@ func startServer(addr string) {
 				p := common.HexToAddress(in.Address)
 				t0 := common.HexToAddress(in.Token0)
 				t1 := common.HexToAddress(in.Token1)
-				marketStore.AddPool(p, t0, t1)
-				if regClient != nil {
-					if _, ok := knownTokens[t0]; !ok {
-						if tx, err := regClient.AddToken(t0, 18); err == nil {
-							log.Printf("registry add token %s tx=%s", t0.Hex(), tx.Hash().Hex())
-							knownTokens[t0] = struct{}{}
-						} else {
-							log.Printf("registry token0 error: %v", err)
-						}
-					}
-					if _, ok := knownTokens[t1]; !ok {
-						if tx, err := regClient.AddToken(t1, 18); err == nil {
-							log.Printf("registry add token %s tx=%s", t1.Hex(), tx.Hash().Hex())
-							knownTokens[t1] = struct{}{}
-						} else {
-							log.Printf("registry token1 error: %v", err)
-						}
-					}
-					if _, ok := knownPools[p]; !ok {
-						if tx, err := regClient.AddPool(p, t0, t1, 0); err == nil {
-							log.Printf("registry add pool %s tx=%s", p.Hex(), tx.Hash().Hex())
-							knownPools[p] = struct{}{}
-						} else {
-							log.Printf("registry pool error: %v", err)
-						}
-					}
-				}
+				recordPool(p, t0, t1)
 			}
 			w.WriteHeader(http.StatusOK)
 		default:


### PR DESCRIPTION
## Summary
- centralize pool caching and registry updates in new `recordPool` helper
- call `recordPool` from factory event handler and API

## Testing
- `go test ./... -mod=mod`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_686e0cc0cad88323ad4b94f1d41e6311